### PR TITLE
Check for User.id before accessing it

### DIFF
--- a/lib/trebuchet/strategy/percentage.rb
+++ b/lib/trebuchet/strategy/percentage.rb
@@ -11,7 +11,11 @@ class Trebuchet::Strategy::Percentage < Trebuchet::Strategy::Base
   end
 
   def launch_at?(user, request = nil)
-    (user.id + offset) % 100 < percentage
+    if user.id.nil?
+      false
+    else
+      (user.id + offset) % 100 < percentage
+    end
   end
 
 end

--- a/spec/percentage_strategy_spec.rb
+++ b/spec/percentage_strategy_spec.rb
@@ -6,6 +6,11 @@ describe Trebuchet::Strategy::Percentage do
     99 # only works if feature name is 'percentage'
   end
 
+  it "should not launch to unsaved users, users with no IDs" do
+    Trebuchet.aim('percentage', :percent, 5)
+    should_not_launch('percentage', [nil])
+  end
+
   it "should only launch to a percentage of users" do
     Trebuchet.aim('percentage', :percent, 5)
     should_launch('percentage', [0, 1, 2, 3, 4, 100, 101, 102, 103, 104].map{|i| i - offset})


### PR DESCRIPTION
If a user object has not been saved and therefore doesn't have an ID, it currently raises an error:

```
NoMethodError:
  undefined method `+' for nil:NilClass
# ./lib/trebuchet/strategy/percentage.rb:14:in `launch_at?
# ./lib/trebuchet/feature.rb:30:in `launch_at?'
# ./lib/trebuchet.rb:47:in `launch?'
# ./spec/percentage_strategy_spec.rb:11:in `block (2 levels) in <top (required)>'
```

Trebuchet will now return `false` for users without IDs instead of raising an error.
